### PR TITLE
file_exists: use utils.file_info() instead of io.open()

### DIFF
--- a/build/webm.lua
+++ b/build/webm.lua
@@ -99,7 +99,7 @@ seconds_to_path_element = function(seconds, no_ms, full)
 end
 local file_exists
 file_exists = function(name)
-  local info, err = utils.file_info(name, "r")
+  local info, err = utils.file_info(name)
   if info ~= nil then
     return true
   end
@@ -1137,7 +1137,6 @@ encode = function(region, startTime, endTime)
   else
     local _
     dir, _ = utils.split_path(path)
-    msg.verbose("Directory", dir)
   end
   if options.output_directory ~= "" then
     dir = parse_directory(options.output_directory)

--- a/build/webm.lua
+++ b/build/webm.lua
@@ -99,9 +99,8 @@ seconds_to_path_element = function(seconds, no_ms, full)
 end
 local file_exists
 file_exists = function(name)
-  local f = io.open(name, "r")
-  if f ~= nil then
-    io.close(f)
+  local info, err = utils.file_info(name, "r")
+  if info ~= nil then
     return true
   end
   return false
@@ -1138,6 +1137,7 @@ encode = function(region, startTime, endTime)
   else
     local _
     dir, _ = utils.split_path(path)
+    msg.verbose("Directory", dir)
   end
   if options.output_directory ~= "" then
     dir = parse_directory(options.output_directory)

--- a/src/util.moon
+++ b/src/util.moon
@@ -31,9 +31,8 @@ seconds_to_path_element = (seconds, no_ms, full) ->
 	return time_string
 
 file_exists = (name) ->
-	f = io.open(name, "r")
-	if f ~= nil
-		io.close(f)
+	info, err = utils.file_info(name)
+	if info ~= nil
 		return true
 	return false
 


### PR DESCRIPTION
On Windows, io.open fails with UTF-8 (and possibly any non-system-conforming) encodings. It seems `utils.file_info` already handles this so we're good.

Fixes #43.

