### PR TITLE
EncodeWithProgress: emit \n on term-status-msg

### DIFF
--- a/build/webm.lua
+++ b/build/webm.lua
@@ -1130,7 +1130,7 @@ do
         copy_command_line = _accum_0
       end
       append(copy_command_line, {
-        '--term-status-msg=Encode time-pos: ${=time-pos}'
+        '--term-status-msg=Encode time-pos: ${=time-pos}\\n'
       })
       self:show()
       local processFd = run_subprocess_popen(copy_command_line)

--- a/src/EncodeWithProgress.moon
+++ b/src/EncodeWithProgress.moon
@@ -30,7 +30,7 @@ class EncodeWithProgress extends Page
 
 	startEncode: (command_line) =>
 		copy_command_line = [arg for arg in *command_line]
-		append(copy_command_line, { '--term-status-msg=Encode time-pos: ${=time-pos}' })
+		append(copy_command_line, { '--term-status-msg=Encode time-pos: ${=time-pos}\\n' })
 		self\show!
 		processFd = run_subprocess_popen(copy_command_line)
 		for line in processFd\lines()


### PR DESCRIPTION
It seems that recent versions of mpv stopped emitting newlines on `term-status-msg`, unless explicitly told to do so. Should fix #73.