### PR TITLE
encode, formats: add support for audio only formats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ SOURCES += src/formats/base.moon
 SOURCES += src/formats/rawvideo.moon
 SOURCES += src/formats/webm.moon
 SOURCES += src/formats/mp4.moon
+SOURCES += src/formats/mp3.moon
 SOURCES += src/Page.moon
 SOURCES += src/EncodeWithProgress.moon
 SOURCES += src/encode.moon

--- a/src/EncodeOptionsPage.moon
+++ b/src/EncodeOptionsPage.moon
@@ -142,7 +142,7 @@ class EncodeOptionsPage extends Page
 
 		-- I really dislike hardcoding this here, but, as said below, order in dicts isn't
 		-- guaranteed, and we can't use the formats dict keys.
-		formatIds = {"webm-vp8", "webm-vp9", "mp4", "mp4-nvenc", "raw"}
+		formatIds = {"webm-vp8", "webm-vp9", "mp4", "mp4-nvenc", "raw", "mp3"}
 		formatOpts =
 			possibleValues: [{fId, formats[fId].displayName} for fId in *formatIds]
 

--- a/src/formats/base.moon
+++ b/src/formats/base.moon
@@ -20,3 +20,14 @@ class Format
 
 	-- A list of flags, to be appended to the command line.
 	getFlags: => {}
+
+	-- The codec flags (ovc and oac)
+	getCodecFlags: =>
+		codecs = {}
+		if @videoCodec != ""
+			codecs[#codecs + 1] = "--ovc=#{@videoCodec}"
+		
+		if @audioCodec != ""
+			codecs[#codecs + 1] = "--oac=#{@audioCodec}"
+		
+		return codecs

--- a/src/formats/mp3.moon
+++ b/src/formats/mp3.moon
@@ -1,0 +1,10 @@
+class MP3 extends Format
+    new: =>
+		@displayName = "MP3 (libmp3lame)"
+		@supportsTwopass = false -- uhh
+		@videoCodec = ""
+		@audioCodec = "libmp3lame"
+		@outputExtension = "mp3"
+		@acceptsBitrate = true
+
+formats["mp3"] = MP3!


### PR DESCRIPTION
~~hope this doesn't break everything~~

Adds support for formats with only audio codecs. Essentially, just added some guards around video flags (which is what most of the logic of the script is around), and changed how bitrate is calculated to accomodate to this change (there's not always a video track, after all).

Closes #85 