### PR TITLE
Recursive expansion in output template

### DIFF
--- a/src/options.lua
+++ b/src/options.lua
@@ -18,6 +18,8 @@ local options = {
 	-- %S, %E - Start and end time, without milliseconds
 	-- %M - "-audio", if audio is enabled, empty otherwise
 	-- %R - "-(height)p", where height is the video's height, or scale_height, if it's enabled.
+	-- More specifiers are supported, see https://mpv.io/manual/master/#options-screenshot-template
+	-- Property expansion is supported (with %{} at top level, ${} when nested), see https://mpv.io/manual/master/#property-expansion
 	output_template = "%F-[%s-%e]%M",
 	-- Scale video to a certain height, keeping the aspect ratio. -1 disables it.
 	scale_height = -1,


### PR DESCRIPTION
Continuation of the work in #92 
The original PR would use the first fallback value for all properties of the same name, e.g. `%{someproperty:fallbackone} %{otherproperty:fallbacktwo} %{someproperty:fallbackthree}` would result in `fallbackone fallbacktwo fallbackone`. This is fixed.

This supports recursive expansion and comparisons like `%{?video-frame-info/picture-type==I:keyframe${estimated-frame-number:X}}`.
Didn't use `expand-text` as it doesn't support `%{}` and because of other annoyances I touch on later.

It has the same limitations as `--screenshot-template`, a closing curly bracket will close all previous curly brackets, regardless of nesting.
This means that instead of `%{!fps==22:${height}p}` you have to write `%{!fps==22:${height}}%{!fps==22:p}`.
If mpv logic ever changes to fix this, we should follow suit.
The only difference with mpv logic currently is that we don't close brackets for the user. With `--screenshot-template` the above example would be `%{!fps==22:${height}%{!fps==22:p}` (notice the confusing uneven brackets).
As a result, some things like `%{!title==${media-title}:untitled}` cannot be expressed at all.
