### PR TITLE
Respect vsfilter aspect ratio setting

### DIFF
--- a/build/webm.lua
+++ b/build/webm.lua
@@ -1451,6 +1451,7 @@ get_playback_options = function()
   local ret = { }
   append_property(ret, "sub-ass-override")
   append_property(ret, "sub-ass-force-style")
+  append_property(ret, "sub-ass-vsfilter-aspect-compat")
   append_property(ret, "sub-auto")
   append_property(ret, "sub-delay")
   append_property(ret, "video-rotate")

--- a/src/encode.moon
+++ b/src/encode.moon
@@ -98,6 +98,7 @@ get_playback_options = ->
 	ret = {}
 	append_property(ret, "sub-ass-override")
 	append_property(ret, "sub-ass-force-style")
+	append_property(ret, "sub-ass-vsfilter-aspect-compat")
 	append_property(ret, "sub-auto")
 	append_property(ret, "sub-delay")
 	append_property(ret, "video-rotate")


### PR DESCRIPTION
Some releases require `--sub-ass-vsfilter-aspect-compat=no` to display properly.
This change reflects its current value in the output video.
There are other properties that one may want to keep, open to discussion about that before merge.