### PR TITLE
Switch from vorbis audio to opus audio

### DIFF
--- a/build/webm.lua
+++ b/build/webm.lua
@@ -45,7 +45,7 @@ local options = {
 	-- In kilobits.
 	strict_audio_bitrate = 64,
 	-- Sets the output format, from a few predefined ones.
-	-- Currently we have webm-vp8 (libvpx/libvorbis), webm-vp9 (libvpx-vp9/libvorbis)
+	-- Currently we have webm-vp8 (libvpx/libvorbis), webm-vp9 (libvpx-vp9/libopus)
 	-- and raw (rawvideo/pcm_s16le).
 	output_format = "webm-vp8",
 	twopass = false,
@@ -972,7 +972,7 @@ do
       self.displayName = "WebM (VP9)"
       self.supportsTwopass = true
       self.videoCodec = "libvpx-vp9"
-      self.audioCodec = "libvorbis"
+      self.audioCodec = "libopus"
       self.outputExtension = "webm"
       self.acceptsBitrate = true
     end,

--- a/src/formats/webm.moon
+++ b/src/formats/webm.moon
@@ -35,7 +35,7 @@ class WebmVP9 extends Format
 		@displayName = "WebM (VP9)"
 		@supportsTwopass = true
 		@videoCodec = "libvpx-vp9"
-		@audioCodec = "libvorbis"
+		@audioCodec = "libopus"
 		@outputExtension = "webm"
 		@acceptsBitrate = true
 

--- a/src/options.lua
+++ b/src/options.lua
@@ -40,7 +40,7 @@ local options = {
 	-- In kilobits.
 	strict_audio_bitrate = 64,
 	-- Sets the output format, from a few predefined ones.
-	-- Currently we have webm-vp8 (libvpx/libvorbis), webm-vp9 (libvpx-vp9/libvorbis)
+	-- Currently we have webm-vp8 (libvpx/libvorbis), webm-vp9 (libvpx-vp9/libopus)
 	-- and raw (rawvideo/pcm_s16le).
 	output_format = "webm-vp8",
 	twopass = false,


### PR DESCRIPTION
Opus is already used by YouTube and supported by default on just about
every distribution's build of mpv/ffmpeg. It gets much better
compression ratios without a loss in quality