### PR TITLE
Add deinterlace property to playback options

### DIFF
--- a/src/encode.moon
+++ b/src/encode.moon
@@ -108,6 +108,7 @@ get_playback_options = ->
 	append_property(ret, "sub-delay")
 	append_property(ret, "video-rotate")
 	append_property(ret, "ytdl-format")
+	append_property(ret, "deinterlace")
 
 	return ret
 


### PR DESCRIPTION
I've been using mpv-webm with some interlaced videos, and I've noticed the output has interlacing artifacts. I've added the `deinterlace` property to the playback options so that its current state is passed.