### PR TITLE
Generate gifs with palletegen/paletteuse

### DIFF
--- a/src/encode.moon
+++ b/src/encode.moon
@@ -348,6 +348,8 @@ encode = (region, startTime, endTime) ->
 			msg.verbose("Patching libvpx pass log file...")
 			vp8_patch_logfile(get_pass_logfile_path(out_path), endTime - startTime)
 
+	command = format\postCommandModifier(command, region, startTime, endTime)
+
 	msg.info("Encoding to", out_path)
 	msg.verbose("Command line:", table.concat(command, " "))
 

--- a/src/formats/base.moon
+++ b/src/formats/base.moon
@@ -31,3 +31,7 @@ class Format
 			codecs[#codecs + 1] = "--oac=#{@audioCodec}"
 		
 		return codecs
+
+	-- Method to modify commandline arguments just before the command is executed
+	postCommandModifier: (command, region, startTime, endTime) =>
+		return command

--- a/src/formats/gif.moon
+++ b/src/formats/gif.moon
@@ -7,4 +7,56 @@ class GIF extends Format
 		@outputExtension = "gif"
 		@acceptsBitrate = false
 
+	postCommandModifier: (command, region, startTime, endTime) =>
+		new_command = {}
+
+		start_ts = seconds_to_time_string(startTime, false, true)
+		end_ts = seconds_to_time_string(endTime, false, true)
+		-- Escape hell...
+		start_ts = start_ts\gsub(":", "\\\\:")
+		end_ts = end_ts\gsub(":", "\\\\:")
+
+		-- Need to use both trim and --start/--end
+		cfilter = "[vid1]trim=start=#{start_ts}:end=#{end_ts}[vidtmp];"
+
+		-- We iterate over commands in the order they are.
+		-- The order is OK except for deinterlace which needs to be applied first:
+		if mp.get_property("deinterlace") == "yes"
+			cfilter = cfilter .. "[vidtmp]yadif=mode=1[vidtmp];"
+
+		-- Remove vf-add commands and prepare a complex filter
+		for _, v in ipairs command
+			-- Other possible vf commands may be OK, but only convert fps, scale, crop and rotate for now
+			if v\match("^%-%-vf%-add=lavfi%-scale") or v\match("^%-%-vf%-add=lavfi%-crop") or v\match("^%-%-vf%-add=fps")
+				n = v\gsub("^%-%-vf%-add=", "")\gsub("^lavfi%-", "")
+				cfilter = cfilter .. "[vidtmp]#{n}[vidtmp];"
+			else if v\match("^%-%-video%-rotate=90")
+				cfilter = cfilter .. "[vidtmp]transpose=1[vidtmp];"
+			else if v\match("^%-%-video%-rotate=270")
+				cfilter = cfilter .. "[vidtmp]transpose=2[vidtmp];"
+			else if v\match("^%-%-video%-rotate=180")
+				cfilter = cfilter .. "[vidtmp]transpose=1[vidtmp];[vidtmp]transpose=1[vidtmp];"
+			else if v\match("^%-%-deinterlace=")
+				-- Drop deinterlace option, yadif filter applied added above instead
+				continue
+			else
+				-- Copy rest of the commands as they are (some might break palette use)
+				append(new_command, {v})
+				continue
+
+		-- complete the complex filter with split->palettegen->paletteuse
+		cfilter = cfilter .. "[vidtmp]split[topal][vidf];"
+		cfilter = cfilter .. "[topal]palettegen[pal];"
+		-- not sure if fifo is necessary but some examples online use it. it doesn't hurt to add
+		cfilter = cfilter .. "[vidf]fifo[vidf];"
+
+		if options.gif_dither == 6
+			cfilter = cfilter .. "[vidf][pal]paletteuse[vo]"
+		else
+			cfilter = cfilter .. "[vidf][pal]paletteuse=dither=bayer:bayer_scale=#{options.gif_dither}:diff_mode=rectangle[vo]"
+
+		append(new_command, { "--lavfi-complex=#{cfilter}" })
+
+		return new_command
+
 formats["gif"] = GIF!

--- a/src/options.lua
+++ b/src/options.lua
@@ -71,7 +71,9 @@ local options = {
 	-- The font size used in the menu. Isn't used for the notifications (started encode, finished encode etc)
 	font_size = 28,
 	margin = 10,
-	message_duration = 5
+	message_duration = 5,
+	-- gif dither mode, 0-5 for bayer w/ bayer_scale 0-5, 6 for paletteuse default (sierra2_4a)
+	gif_dither = 2
 }
 
 mpopts.read_options(options)


### PR DESCRIPTION
Hi,

This is my attempt to address #111 

To generate higher quality gifs this PR changes the gif format to use palettes. The `paletteuse` filter that achieves this requires complex filters to be used with `--lavfi-complex`, and this doesn't seem to play well with some other `--vf-add` options. The solution I came up with was to add a `postCommandModifier` method to the `Format` class that can alter the command line arguments. In the gif case it goes over the list and and tries to convert various options to their complex filter equivalents. I don't know if this is acceptable but I can try to change it if there's a better way.

I also added a new option to `options.lua` to change the dither flags to use for `palleteuse`.

Edit:
Fixed typo