### PR TITLE
Add 'Force Square Pixels' option

### DIFF
--- a/src/EncodeOptionsPage.moon
+++ b/src/EncodeOptionsPage.moon
@@ -175,6 +175,7 @@ class EncodeOptionsPage extends Page
 			{"crf", Option("int", "CRF", options.crf, crfOpts)},
 			{"fps", Option("list", "FPS", options.fps, fpsOpts)},
 			{"gif_dither", Option("list", "GIF Dither Type", options.gif_dither, gifDitherOpts, -> @options[1][2]\getValue! == "gif")},
+			{"force_square_pixels", Option("bool", "Force Square Pixels", options.force_square_pixels)},
 		}
 
 		@keybinds =

--- a/src/encode.moon
+++ b/src/encode.moon
@@ -74,9 +74,12 @@ append_audio_tracks = (out, tracks) ->
 		append_track(out, internal_tracks[1])
 
 get_scale_filters = ->
+	filters = {}
+	if options.force_square_pixels
+		append(filters, {"lavfi-scale=iw*sar:ih"})
 	if options.scale_height > 0
-		return {"lavfi-scale=-2:#{options.scale_height}"}
-	return {}
+		append(filters, {"lavfi-scale=-2:#{options.scale_height}"})
+	return filters
 
 get_fps_filters = ->
 	if options.fps > 0

--- a/src/options.lua
+++ b/src/options.lua
@@ -73,7 +73,10 @@ local options = {
 	margin = 10,
 	message_duration = 5,
 	-- gif dither mode, 0-5 for bayer w/ bayer_scale 0-5, 6 for paletteuse default (sierra2_4a)
-	gif_dither = 2
+	gif_dither = 2,
+	-- Force square pixels on output video
+	-- Some players like recent Firefox versions display videos with non-square pixels with wrong aspect ratio
+	force_square_pixels = false,
 }
 
 mpopts.read_options(options)


### PR DESCRIPTION
Hi,

I've noticed that newer versions of Firefox display some videos I create with the wrong aspect ratio. Digging a bit, it looks like it started having issues with webms with non-square pixels. This change adds another filter to convert the video to square pixels before doing scaling.

Seems like it's a known bug on Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1697316

Coincidentally, this also fixes #104 I think