### PR TITLE
Fix gif usage with lavfi-eq - Grainy gifs

### DIFF
--- a/src/formats/gif.moon
+++ b/src/formats/gif.moon
@@ -26,8 +26,9 @@ class GIF extends Format
 
 		-- Remove vf-add commands and prepare a complex filter
 		for _, v in ipairs command
-			-- Other possible vf commands may be OK, but only convert fps, scale, crop and rotate for now
-			if v\match("^%-%-vf%-add=lavfi%-scale") or v\match("^%-%-vf%-add=lavfi%-crop") or v\match("^%-%-vf%-add=fps")
+			-- Other possible vf commands may be OK, but only convert fps, scale, crop, rotate and eq for now
+			if v\match("^%-%-vf%-add=lavfi%-scale") or v\match("^%-%-vf%-add=lavfi%-crop") or
+				   v\match("^%-%-vf%-add=fps") or v\match("^%-%-vf%-add=lavfi%-eq")
 				n = v\gsub("^%-%-vf%-add=", "")\gsub("^lavfi%-", "")
 				cfilter = cfilter .. "[vidtmp]#{n}[vidtmp];"
 			else if v\match("^%-%-video%-rotate=90")


### PR DESCRIPTION
Someone reported grainy gifs in the latest version: https://github.com/ekisu/mpv-webm/issues/111#issuecomment-942031329

This change should fix it. It adds the new filter that was introduced in 7041c07 to the list the gif class manually handles.

