### PR TITLE
Use better quality defaults

### DIFF
--- a/src/formats/webm.moon
+++ b/src/formats/webm.moon
@@ -25,7 +25,11 @@ class WebmVP8 extends Format
 
 	getFlags: =>
 		{
-			"--ovcopts-add=threads=#{options.libvpx_threads}"
+			"--ovcopts-add=threads=#{options.libvpx_threads}",
+			"--ovcopts-add=auto-alt-ref=1",
+			"--ovcopts-add=lag-in-frames=25",
+			"--ovcopts-add=quality=good",
+			"--ovcopts-add=cpu-used=0",
 		}
 
 formats["webm-vp8"] = WebmVP8!

--- a/src/formats/webm.moon
+++ b/src/formats/webm.moon
@@ -37,7 +37,7 @@ formats["webm-vp8"] = WebmVP8!
 class WebmVP9 extends Format
 	new: =>
 		@displayName = "WebM (VP9)"
-		@supportsTwopass = true
+		@supportsTwopass = false
 		@videoCodec = "libvpx-vp9"
 		@audioCodec = "libopus"
 		@outputExtension = "webm"

--- a/src/options.lua
+++ b/src/options.lua
@@ -51,7 +51,7 @@ local options = {
 	-- mp3 (libmp3lame)
 	-- and gif
 	output_format = "webm-vp8",
-	twopass = false,
+	twopass = true,
 	-- If set, applies the video filters currently used on the playback to the encode.
 	apply_current_filters = true,
 	-- If set, writes the video's filename to the "Title" field on the metadata.


### PR DESCRIPTION
Taken from the [VP8 Encode Parameter Guide](https://www.webmproject.org/docs/encoder-parameters/). Should improve mostly twopass only, so for now twopass is the default. ~~hopefully nothing breaks~~