### PR TITLE
fix avc-nvenc format

### DIFF
--- a/src/formats/avc.moon
+++ b/src/formats/avc.moon
@@ -22,5 +22,9 @@ class AVCNVENC extends Format
 		@audioCodec = "aac"
 		@outputExtension = "mp4"
 		@acceptsBitrate = true
-
+	getFlags: =>
+		{
+			-- nothing above p2 works for me
+			"--ovcopts-add=preset=p2"
+		}
 formats["avc-nvenc"] = AVCNVENC!


### PR DESCRIPTION
Could easily be just a me issue, but nvenc encodes always seem to fail with `'pts () < dts () in stream 0` errors without this flag. 

I'm on windows and have a ampere gpu if that's any help.
