### PR TITLE
add bindings to jump to start/end times of the selected export region

### DIFF
--- a/src/MainPage.moon
+++ b/src/MainPage.moon
@@ -4,6 +4,8 @@ class MainPage extends Page
 			"c": self\crop
 			"1": self\setStartTime
 			"2": self\setEndTime
+			"!": self\jumpToStartTime
+			"@": self\jumpToEndTime
 			"o": self\changeOptions
 			"p": self\preview
 			"e": self\encode
@@ -23,7 +25,13 @@ class MainPage extends Page
 		if @visible
 			self\clear!
 			self\draw!
-	
+
+	jumpToStartTime: =>
+		mp.set_property("time-pos", @startTime)
+
+	jumpToEndTime: =>
+		mp.set_property("time-pos", @endTime)
+
 	setupStartAndEndTimes: =>
 		if mp.get_property_native("duration")
 			-- Note: there exists an option called rebase-start-time, which, when set to no,
@@ -48,6 +56,8 @@ class MainPage extends Page
 		ass\append("#{bold('c:')} crop\\N")
 		ass\append("#{bold('1:')} set start time (current is #{seconds_to_time_string(@startTime)})\\N")
 		ass\append("#{bold('2:')} set end time (current is #{seconds_to_time_string(@endTime)})\\N")
+		ass\append("#{bold('!:')} jump to start time\\N")
+		ass\append("#{bold('@:')} jump to end time\\N")
 		ass\append("#{bold('o:')} change encode options\\N")
 		ass\append("#{bold('p:')} preview\\N")
 		ass\append("#{bold('e:')} encode\\N\\N")


### PR DESCRIPTION
This PR adds keys `!` (`shift+1`) and `@` (`shift+2`)  as bindings to jump to the start and end time of the excerpt, respectively.

This is useful when attempting to export a "perfect loop" for example, but they're also useful in general when refining the export region.

I'm not attached to `shift+1`/`shift+2` as keybindings, so if you think they should be changed to something else, I can change them. Or if you think they should show up in the OSD as `shift+1`/`shift+2` instead of `!` and `@`.