### PR TITLE
Add support for a sequence number

### DIFF
--- a/src/encode.moon
+++ b/src/encode.moon
@@ -349,8 +349,7 @@ encode = (region, startTime, endTime) ->
 	if options.output_directory != ""
 		dir = parse_directory(options.output_directory)
 
-	formatted_filename = format_filename(originalStartTime, originalEndTime, format)
-	out_path = utils.join_path(dir, formatted_filename)
+	out_path = format_filename(originalStartTime, originalEndTime, format, dir)
 	append(command, {"--o=#{out_path}"})
 
 	emit_event("encode-started")

--- a/src/options.lua
+++ b/src/options.lua
@@ -20,6 +20,7 @@ local options = {
 	-- %S, %E - Start and end time, without milliseconds
 	-- %M - "-audio", if audio is enabled, empty otherwise
 	-- %R - "-(height)p", where height is the video's height, or scale_height, if it's enabled.
+	-- %[#]0Xn - Sequence number, padded with zeros to length X, if # is specified then the lowest number available will be used
 	-- More specifiers are supported, see https://mpv.io/manual/master/#options-screenshot-template
 	-- Property expansion is supported (with %{} at top level, ${} when nested), see https://mpv.io/manual/master/#property-expansion
 	output_template = "%F-[%s-%e]%M",

--- a/src/util.moon
+++ b/src/util.moon
@@ -96,13 +96,14 @@ add_sequence_number = (global_mode, dir, filename, extension) ->
 		if not global_mode
 			videono = 1
 		while true
+			-- replace pattern with padded sequence number
 			out_filename, _ = filename\gsub(pattern_sub, string.format(pattern_pad, videono))
 			file = utils.join_path(dir, "#{out_filename}.#{extension}")
 			videono = videono + 1
 			-- return file if it doesn't exist
 			if not utils.file_info(file)
 				return file
-			-- quit if number is not  less than 100000 - 1 (mpv limit)
+			-- quit if number is not less than 100000 - 1 (mpv limit)
 			if not (videono < 100000 - 1)
 				return nil
 
@@ -167,6 +168,7 @@ format_filename = (startTime, endTime, videoFormat, dir) ->
 
 	result = nil
 	global_mode = filename\match(global_sequence_pattern)
+	-- run only if either pattern is present
 	if global_mode or filename\match(local_sequence_pattern)
 		result = add_sequence_number(global_mode, dir, filename, videoFormat.outputExtension)
 	return result or utils.join_path(dir, "#{filename}.#{videoFormat.outputExtension}")

--- a/src/util.moon
+++ b/src/util.moon
@@ -97,11 +97,14 @@ add_sequence_number = (global_mode, dir, filename, extension) ->
 			videono = 1
 		while true
 			out_filename, _ = filename\gsub(pattern_sub, string.format(pattern_pad, videono))
-			print(videono, out_filename, extension)
 			file = utils.join_path(dir, "#{out_filename}.#{extension}")
 			videono = videono + 1
+			-- return file if it doesn't exist
 			if not utils.file_info(file)
 				return file
+			-- quit if number is not  less than 100000 - 1 (mpv limit)
+			if not (videono < 100000 - 1)
+				return nil
 
 format_filename = (startTime, endTime, videoFormat, dir) ->
 	hasAudioCodec = videoFormat.audioCodec != ""
@@ -162,8 +165,10 @@ format_filename = (startTime, endTime, videoFormat, dir) ->
 	-- Linux: /
 	filename, _ = filename\gsub("[<>:\"/\\|?*]", "")
 
-	global_mode = filename\match(global_sequence_pattern) and true or filename\match(local_sequence_pattern) and false
-	result = add_sequence_number(global_mode, dir, filename, videoFormat.outputExtension)
+	result = nil
+	global_mode = filename\match(global_sequence_pattern)
+	if global_mode or filename\match(local_sequence_pattern)
+		result = add_sequence_number(global_mode, dir, filename, videoFormat.outputExtension)
 	return result or utils.join_path(dir, "#{filename}.#{videoFormat.outputExtension}")
 
 parse_directory = (dir) ->


### PR DESCRIPTION
As a continuation to #92 and #93, this PR adds a simple implementation of [`%[#][0X]n`](https://mpv.io/manual/master/#options-%%5B#%5D%5B0x%5Dn) with some limitations:

- Only one pattern -- one `%0Xn` or one `%#0Xn` -- is allowed.
- If both present, between `%0Xn` and `%#0Xn`, the first takes priority, the second one is ignored.
- Everything else works as you would expect it from mpv.

To be honest, I don't see a reason why anyone would include both patterns or the same pattern more than once in the template, besides, it also confuses mpv itself.