### PR TITLE
Add target file size to replace table

### DIFF
--- a/src/util.moon
+++ b/src/util.moon
@@ -112,6 +112,7 @@ format_filename = (startTime, endTime, videoFormat) ->
 		"%%T": mp.get_property("media-title")
 		"%%M": (mp.get_property_native('aid') and not mp.get_property_native('mute') and hasAudioCodec) and '-audio' or ''
 		"%%R": (options.scale_height != -1) and "-#{options.scale_height}p" or "-#{mp.get_property_native('height')}p"
+		"%%mb" = options.target_filesize/1000
 		"%%t%%": "%%"
 	filename = options.output_template
 


### PR DESCRIPTION
I write the file size to the name of the encoded file because different platforms have different upload limits. I often encode the same clip at different file sizes and differentiate the names by file size so that they don't overwrite. I do this by adding the following line to webm.lua. It would be nice if this was part of the official script so that I don't need to edit it each time I update.