### PR TITLE
Add options.target_filesize to replace table

### DIFF
--- a/src/util.moon
+++ b/src/util.moon
@@ -112,6 +112,7 @@ format_filename = (startTime, endTime, videoFormat) ->
 		"%%T": mp.get_property("media-title")
 		"%%M": (mp.get_property_native('aid') and not mp.get_property_native('mute') and hasAudioCodec) and '-audio' or ''
 		"%%R": (options.scale_height != -1) and "-#{options.scale_height}p" or "-#{mp.get_property_native('height')}p"
+		"%%mb": options.target_filesize/1000
 		"%%t%%": "%%"
 	filename = options.output_template
 


### PR DESCRIPTION
This commit adds options.target_filesize to the replace table for writing file names. This is a change I always add when updating webm.lua. This is added because different platforms have different file size upload limits, so I often encode the same clip at different file sizes. The file names are then differentiated by size so that they don't overwrite. I'm submitting a pull request for this so that I don't need to re-add this to the script every time I update it.