### PR TITLE
Update deprecated sub option

### DIFF
--- a/src/encode.moon
+++ b/src/encode.moon
@@ -139,7 +139,7 @@ get_sub_options = ->
 	ret = {}
 	append_property(ret, "sub-ass-override")
 	append_property(ret, "sub-ass-force-style")
-	append_property(ret, "sub-ass-vsfilter-aspect-compat")
+	append_property(ret, "sub-ass-use-video-data=aspect-ratio")
 	append_property(ret, "sub-auto")
 	append_property(ret, "sub-pos")
 	append_property(ret, "sub-delay")

--- a/src/encode.moon
+++ b/src/encode.moon
@@ -139,7 +139,7 @@ get_sub_options = ->
 	ret = {}
 	append_property(ret, "sub-ass-override")
 	append_property(ret, "sub-ass-force-style")
-	append_property(ret, "sub-ass-use-video-data=aspect-ratio")
+	append_property(ret, "sub-ass-use-video-data")
 	append_property(ret, "sub-auto")
 	append_property(ret, "sub-pos")
 	append_property(ret, "sub-delay")


### PR DESCRIPTION
The `sub-ass-vsfilter-aspect-compat` option has been removed from mpv. This change uses the new option.

![image](https://github.com/user-attachments/assets/acba8f12-256f-4b37-a609-724d855ecba0)
