### PR TITLE
Add option to run mpv command on successful encode

### DIFF
--- a/src/encode.moon
+++ b/src/encode.moon
@@ -429,6 +429,8 @@ encode = (region, startTime, endTime) ->
 		if res
 			message("Encoded successfully! Saved to\\N#{bold(out_path)}")
 			emit_event("encode-finished", "success")
+			if options.completion_command != ""
+				mp.command(options.completion_command\gsub("%%{output}", out_path))
 		else
 			message("Encode failed! Check the logs for details.")
 			emit_event("encode-finished", "fail")

--- a/src/options.lua
+++ b/src/options.lua
@@ -79,6 +79,9 @@ local options = {
 	-- Force square pixels on output video
 	-- Some players like recent Firefox versions display videos with non-square pixels with wrong aspect ratio
 	force_square_pixels = false,
+    -- MPV command to run upon successful encoding
+    -- %{output} will be replaced with the path to the resulting file.
+    completion_command = "",
 }
 
 mpopts.read_options(options)


### PR DESCRIPTION
This PR adds an option `completion_command`, which, when set, will cause mpv-webm to run the specified mpv command when the encoding completes successfully.

The string `%{output}` will be replaced with the path to the output file.

This may be useful, for example, to automatically copy the path to the system clipboard, i.e.:

`completion_command=set "clipboard/text" "%{output}"`

(Note that `set "clipboard/text"` only works on Windows, Wayland, and macOS).

Alternatively, if you have a script that copies its arguments to the clipboard (as I do, since I use X11):

`completion_command=run "script-for-copying-args-to-clipboard" "%{output}"`

(Unfortunately, `xclip` and `xsel` don't seem to have the ability to copy from arguments, and I'd rather not invoke a subshell if possible just for piping to their stdin. Thus I wrote a small script that pipes into them itself, from its arguments. I find this a cleaner and less hacky solution, personally.)