### PR TITLE
delete x264_2pass.log and x264_2pass.log.mbtree files after encoding

### DIFF
--- a/src/encode.moon
+++ b/src/encode.moon
@@ -438,5 +438,7 @@ encode = (region, startTime, endTime) ->
 		
 		-- Clean up pass log file.
 		os.remove(get_pass_logfile_path(out_path))
+		os.remove "x264_2pass.log"
+		os.remove "x264_2pass.log.mbtree"
 		if is_temporary
 			os.remove(path)


### PR DESCRIPTION
I've been mentioning this bug [here](https://github.com/ekisu/mpv-webm/issues/208)

For some reason function `os.remove(get_pass_logfile_path(out_path))` does not delete files `x264_2pass.log` and `x264_2pass.log.mbtree` after encoding, so I added this workaround to reduce littering in the videofile's path.

I'm not a programmer and never wrote a lua code before so I hope somebody will provide more clean solution.
Anyway I tested it and it works.